### PR TITLE
Fix extension handling

### DIFF
--- a/scripts/random-google-image.sh
+++ b/scripts/random-google-image.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # We stick to jpeg images because some "sourceUrl"s do not contain a file extension
-IMAGE_EXTENSION=jpeg
+IMAGE_FILE_EXTENSION=jpeg
 
 # Get search results via the API
 # Search term: "guten morgen grüße filetype:jpeg"
-SEARCH_RESULTS_JSON=$(curl "https://app.zenserp.com/api/v2/search?apikey=$ZENSERP_API_KEY&q=guten%20morgen%20gr%C3%BC%C3%9Fe%20filetype%3A$IMAGE_EXTENSION&tbm=isch&gl=DE")
+SEARCH_RESULTS_JSON=$(curl "https://app.zenserp.com/api/v2/search?apikey=$ZENSERP_API_KEY&q=guten%20morgen%20gr%C3%BC%C3%9Fe%20filetype%3A$IMAGE_FILE_EXTENSION&tbm=isch&gl=DE")
 
 # Get the number of search results 
 NUM_SEARCH_RESULTS=$(echo $SEARCH_RESULTS_JSON | jq ".image_results | length")
@@ -16,13 +16,15 @@ SEARCH_RESULT_INDEX=$(($RANDOM % $NUM_SEARCH_RESULTS))
 # Get the "sourceUrl" of the random search result
 IMAGE_URL=$(echo $SEARCH_RESULTS_JSON | jq -r ".image_results[$SEARCH_RESULT_INDEX].sourceUrl")
 
+IMAGE_FILE="image.$IMAGE_FILE_EXTENSION"
+
 # Download the actual image
-curl $IMAGE_URL --output image.jpeg
+curl $IMAGE_URL --output $IMAGE_FILE
 
 # Set env vars
 echo "IMAGEURL=$IMAGE_URL" >> $GITHUB_ENV
-echo "IMAGEFILE=image.$IMAGE_EXTENSION" >> $GITHUB_ENV
+echo "IMAGEFILE=$IMAGE_FILE" >> $GITHUB_ENV
 
 # Logging
 echo "image url: $IMAGE_URL"
-echo "image file: image.$IMAGE_EXTENSION"
+echo "image file: $IMAGE_FILE"


### PR DESCRIPTION
Fixes the extension handling by explicitly restricting the file extension to `jpeg`. Trying to figure out the actual image/file type is not easy because it can't be always extracted from the `sourceUrl` of the search result. One would have to check the file header of the image to figure out what we are dealing with.

Also:
- Adds some comments
- Simplifies expressions

Greetings! :)